### PR TITLE
Add cat intro to the repo issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_fact.yml
+++ b/.github/ISSUE_TEMPLATE/add_fact.yml
@@ -9,6 +9,7 @@ body:
         - "a11y-facts"
         - "alan"
         - "cats"
+        - "cat-intros"
         - "dags-alumni"
         - "dags"
         - "dag-intros"


### PR DESCRIPTION
This adds the cat intros into the issue template so people can add them without needing to mess with the code.