### PR TITLE
Fix cat intro images so they unfurl correctly

### DIFF
--- a/cat-intros.json
+++ b/cat-intros.json
@@ -1,4 +1,4 @@
 [
-  "This is Theodosius. He's mostly likely a chartreaux cat, and he's about 20 pounds. He's a lovely shade of gray with white toes on the front feet and white socks on the back feet. He _loves_ string! His human is Sarah. https://gsa.enterprise.slack.com/files/U02C6N7QE91/F02MRT9CHQR/img_20180729_154756_618.jpg",
-  "This is Rorschach. He's mostly likely a chartreaux cat, and he's about 16 pounds. He's about 80% white fur with a gray tail and some gray spots on his back and face. He _loves_ solving puzzle toys! His human is Sarah. https://gsa.enterprise.slack.com/files/U02C6N7QE91/F02N306NDL0/img_20180729_154654_317.jpg"
+  "This is Theodosius. He's mostly likely a chartreaux cat, and he's about 20 pounds. He's a lovely shade of gray with white toes on the front feet and white socks on the back feet. He _loves_ string! His human is Sarah. https://gsa-tts.slack.com/archives/C028GH7FA/p1636998766003100",
+  "This is Rorschach. He's mostly likely a chartreaux cat, and he's about 16 pounds. He's about 80% white fur with a gray tail and some gray spots on his back and face. He _loves_ solving puzzle toys! His human is Sarah. https://gsa-tts.slack.com/archives/C028GH7FA/p1636998761002900"
 ]


### PR DESCRIPTION
Direct links to files, even if they're Slack's, don't unfurl. Linking to the message with the image will.